### PR TITLE
Completely refactored plugin.

### DIFF
--- a/.github/workflows/build_experiment.yml
+++ b/.github/workflows/build_experiment.yml
@@ -1,0 +1,33 @@
+name: Build and Package SFAE
+
+on:
+  push:
+    branches:
+      - 'TwoPointOh'
+  pull_request:
+    branches:
+      - 'TwoPointOh'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            submodules: true
+            ref: 'TwoPointOh'
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build Solution
+        run: |
+          msbuild SFAE.sln /p:Configuration=Release /p:Platform=x64
+
+      - name: Upload Release.zip as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Release
+          path: x64\Release\vcruntime140_1.dll

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,32 @@
+name: Build and Package SFAE
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            submodules: true
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build Solution
+        run: |
+          msbuild SFAE.sln /p:Configuration=Release /p:Platform=x64
+
+      - name: Upload Release.zip as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Release
+          path: x64\Release\vcruntime140_1.dll


### PR DESCRIPTION
Closes #6
Supersedes #7

This removes all the unnecessary extra chuff the original plugin was doing (like creating a thread and checking some pointer) with a singular patch that completely reverts Starfield back to an unmodded state. It will still load creations and mods, but considers them DLC or just random elements that come with the game.