### PR TITLE
Fixes improper C++ preprocessor director.

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -2,10 +2,10 @@
 #include "sfae.h"
 
 // vcruntime140_1.dll exports
-#define DLLPATH "\\\\.\\GLOBALROOT\\SystemRoot\\System32\\vcruntime140_1.dll"
-#pragma comment(linker, "/EXPORT:___CxxFrameHandler4=" DLLPATH ".__CxxFrameHandler4")
-#pragma comment(linker, "/EXPORT:___NLG_Dispatch2=" DLLPATH ".__NLG_Dispatch2")
-#pragma comment(linker, "/EXPORT:___NLG_Return2=" DLLPATH ".__NLG_Return2")
+#define MAKE_EXPORT(func) "/EXPORT:" func "=\\\\.\\GLOBALROOT\\SystemRoot\\System32\\vcruntime140_1.dll." func
+#pragma comment(linker, MAKE_EXPORT("__CxxFrameHandler4"))
+#pragma comment(linker, MAKE_EXPORT("__NLG_Dispatch2"))
+#pragma comment(linker, MAKE_EXPORT("__NLG_Return2"))
 
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,


### PR DESCRIPTION
Closes #17.

This seems to be due to the C++ preprocessor thinking #DLLPATH is a finalized string and injecting a null terminator into the string, thus when appended, it comes out as \\\\.\\GLOBALROOT\\SystemRoot\\System32\\(\0)vcruntime140_1.dll. I found that testing on my desktop the runtime ignored this character and was able to resolve the DLL. My laptop which is also running Windows 11 24H2 as my desktop is, does not. 